### PR TITLE
Ignore incorrect source folders.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "rebater",
   "productName": "Rebater",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "A desktop application to automate Fuse Alliance's Rebate process for its distributors.",
   "main": ".vite/build/main.js",
   "scripts": {

--- a/src/shared/ipc/system/getAllQuarters.ts
+++ b/src/shared/ipc/system/getAllQuarters.ts
@@ -1,4 +1,4 @@
-import { bad, good, Reply } from "../../reply";
+import { good, Reply } from "../../reply";
 import { readdir } from "fs/promises";
 import moment from "moment";
 import { getSettingsInterface } from "./getSettings";
@@ -19,14 +19,10 @@ export async function getAllQuarters(): Promise<Reply<TimeData[]>> {
     if (!directory.isDirectory()) continue;
 
     const time = moment(directory.name, SOURCE_FOLDER_FORMAT);
-    if (!time.isValid()) {
-      return bad(`Time ${directory.name} is not a valid quarter!`);
-    }
+    if (!time.isValid()) continue;
 
     const quarter = time.quarter();
-    if (quarter !== 1 && quarter !== 2 && quarter !== 3 && quarter !== 4) {
-      return bad(`Quarter ${quarter} is not a valid quarter!`);
-    }
+    if (quarter !== 1 && quarter !== 2 && quarter !== 3 && quarter !== 4) continue;
 
     quarters.push({ year: time.year(), quarter });
   }


### PR DESCRIPTION
When the user has folders that do not conform to the `source/<quarter>/<group?/<file>` structure, ignore them, instead of throwing an error.