### PR TITLE
Fix: `<column>` tag may return null.

### DIFF
--- a/src/system/row/Column.ts
+++ b/src/system/row/Column.ts
@@ -3,6 +3,7 @@ import { ExcelIndexSchema, getExcelFromIndex } from "../util";
 import { BaseRow } from ".";
 import { XMLElement } from "xmlbuilder";
 import { makeNodeElementSchema, makeTextElementSchema } from "../xml";
+import assert from "node:assert";
 
 /** ------------------------------------------------------------------------- */
 
@@ -22,7 +23,10 @@ export class ColumnRow implements BaseRow {
   }
 
   async run(_v: string, row: Row): Promise<string> {
-    return row.data[this.index];
+    const value = row.data[this.index];
+    assert.ok(value != null, `Cannot pull column ${this.index + 1} from row: ${row.data}`);
+
+    return value;
   }
 
   public static readonly SCHEMA = z.strictObject({


### PR DESCRIPTION
If the user pull data from a column that does not exist in the row, it returns a null value, invalidating the entire row.